### PR TITLE
Adding direct extraction to the game folder and a new folder select dialogue

### DIFF
--- a/src/CommunityPatchLauncher/Commands/ApplicationWindow/SelectFolderCommand.cs
+++ b/src/CommunityPatchLauncher/Commands/ApplicationWindow/SelectFolderCommand.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Windows.Forms;
+using Microsoft.WindowsAPICodePack.Dialogs;
 
 namespace CommunityPatchLauncher.Commands.ApplicationWindow
 {
@@ -17,21 +18,21 @@ namespace CommunityPatchLauncher.Commands.ApplicationWindow
         /// <inheritdoc/>
         public override void Execute(object parameter)
         {
-            FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog();
-            if (parameter != null && parameter is string stringParameter)
-            {
-                if (Directory.Exists(stringParameter))
-                {
-                    folderBrowserDialog.SelectedPath = stringParameter;
-                }
-            }
-            DialogResult result = folderBrowserDialog.ShowDialog();
-            if (result == DialogResult.OK)
-            {
-                string filePath = folderBrowserDialog.SelectedPath + "\\";
-                data = Directory.Exists(filePath) ? filePath : string.Empty;
-                ExecutionDone();
-            }
-        }
-    }
+			CommonOpenFileDialog dialog = new CommonOpenFileDialog();
+			dialog.IsFolderPicker = true;
+
+			if (parameter != null && parameter is string stringParameter) {
+				if (Directory.Exists(stringParameter)) {
+					dialog.DefaultDirectory = stringParameter;
+				}
+			}
+
+			CommonFileDialogResult result = dialog.ShowDialog();
+			if (result == CommonFileDialogResult.Ok) {
+				string filePath = dialog.FileName + "\\";
+				data = Directory.Exists(filePath) ? filePath : string.Empty;
+				ExecutionDone();
+			}
+		}
+	}
 }

--- a/src/CommunityPatchLauncher/Commands/DataCommands/InstallationFromManuelSelectionCommand.cs
+++ b/src/CommunityPatchLauncher/Commands/DataCommands/InstallationFromManuelSelectionCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using Microsoft.WindowsAPICodePack.Dialogs;
+using System.IO;
 using System.Windows.Forms;
 
 namespace CommunityPatchLauncher.Commands.DataCommands
@@ -17,15 +18,15 @@ namespace CommunityPatchLauncher.Commands.DataCommands
         /// <inheritdoc/>
         public override void Execute(object parameter)
         {
-            FolderBrowserDialog folderBrowserDialog = new FolderBrowserDialog();
+			CommonOpenFileDialog dialog = new CommonOpenFileDialog();
+			dialog.IsFolderPicker = true;
 
-            DialogResult result = folderBrowserDialog.ShowDialog();
-            if (result == DialogResult.OK)
-            {
-                string filePath = folderBrowserDialog.SelectedPath + "\\";
-                data = File.Exists(filePath + "S4_Main.exe") ? filePath : "";
-                ExecutionDone();
-            }
-        }
+			CommonFileDialogResult result = dialog.ShowDialog();
+			if (result == CommonFileDialogResult.Ok) {
+				string filePath = dialog.FileName + "\\";
+				data = File.Exists(filePath + "S4_Main.exe") ? filePath : "";
+				ExecutionDone();
+			}
+		}
     }
 }

--- a/src/CommunityPatchLauncher/CommunityPatchLauncher.csproj
+++ b/src/CommunityPatchLauncher/CommunityPatchLauncher.csproj
@@ -47,6 +47,18 @@
     <Reference Include="Markdig, Version=0.20.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Markdig.0.20.0\lib\netstandard2.0\Markdig.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.WindowsAPICodePack-Core.1.1.0.0\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack.Shell, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.WindowsAPICodePack-Shell.1.1.0.0\lib\Microsoft.WindowsAPICodePack.Shell.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAPICodePack.ShellExtensions, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.WindowsAPICodePack-Shell.1.1.0.0\lib\Microsoft.WindowsAPICodePack.ShellExtensions.dll</HintPath>
+    </Reference>
+    <Reference Include="SharpCompress, Version=0.26.0.0, Culture=neutral, PublicKeyToken=afb0a02973931d96, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\SharpCompress.0.26.0\lib\net46\SharpCompress.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
@@ -157,6 +169,7 @@
     <Compile Include="Tasks\Factories\DownloadOfflineFilesFactory.cs" />
     <Compile Include="Tasks\Factories\LaunchGameFactory.cs" />
     <Compile Include="Tasks\PatchGameSpeedTask.cs" />
+    <Compile Include="Tasks\UnzipAndExtractCommunityPatchTask.cs" />
     <Compile Include="UserControls\ComingSoonControl.xaml.cs">
       <DependentUpon>ComingSoonControl.xaml</DependentUpon>
     </Compile>

--- a/src/CommunityPatchLauncher/Tasks/Factories/LaunchGameFactory.cs
+++ b/src/CommunityPatchLauncher/Tasks/Factories/LaunchGameFactory.cs
@@ -67,8 +67,7 @@ namespace CommunityPatchLauncher.Tasks.Factories
             //returnList.Add(new DownloadCommunityPatchTask(AvailablePatches.CommunityPatchDLC));
             //returnList.Add(new UnzipCommunityPatchTask());
             returnList.Add(new DownloadCommunityPatchTask(patchName));
-            returnList.Add(new UnzipCommunityPatchTask());
-            returnList.Add(new CopyFileToGameFolder());
+            returnList.Add(new UnzipAndExtractCommunityPatchTask());
             returnList.Add(new PatchGameSpeedTask(speedMode));
             returnList.Add(new StartGameTask());
             return returnList;

--- a/src/CommunityPatchLauncher/Tasks/UnzipAndExtractCommunityPatchTask.cs
+++ b/src/CommunityPatchLauncher/Tasks/UnzipAndExtractCommunityPatchTask.cs
@@ -1,0 +1,67 @@
+﻿using CommunityPatchLauncherFramework.Settings.Container;
+using CommunityPatchLauncherFramework.TaskPipeline.Tasks;
+using System;
+using System.IO;
+using SharpCompress;
+using SharpCompress.Archives.SevenZip;
+using System.Linq;
+using SharpCompress.Common;
+using SharpCompress.Archives;
+using SharpCompress.Archives.Zip;
+
+namespace CommunityPatchLauncher.Tasks
+{
+	/// <summary>
+	/// This class will unzip the community patch from its .7z file
+	/// and unzip the zip file inside it and extract all contents to the game folder under "GameFolder"
+	/// </summary>
+	internal class UnzipAndExtractCommunityPatchTask : ProgressAbstractTask
+	{
+		/// <inheritdoc>
+		public override bool Execute(bool previousTaskState) {
+			string filePath = GetSetting<string>("PatchInstaller");
+			if (filePath == null) {
+				TaskDone();
+				return false;
+			}
+			string zipFilePath = filePath;
+			if (!File.Exists(zipFilePath)) {
+				TaskDone();
+				return false;
+			}
+
+			string targetFolder = settingManager.GetValue<string>("GameFolder");
+
+			using (MemoryStream innerArchive = new MemoryStream()) {
+				/*
+					* Patch zip structure:
+					* Patch.7z:
+					* -Patch.zip:
+					* --S4_Main.exe
+					* --binkw32.dll
+					* --...
+					* 
+					* innerArchive: Patch.zip
+					* outerArchive: Patch.7z
+					*/
+
+				//Extract the folder zip inside the 7Zip to a stream.
+				using (var outerArchive = SevenZipArchive.Open(filePath)) {
+					outerArchive.Entries.First().WriteTo(innerArchive);
+				}
+
+				using (var extractedGame = ZipArchive.Open(innerArchive)) {
+					foreach (var entry in extractedGame.Entries.Where(entry => !entry.IsDirectory)) {
+						entry.WriteToDirectory(targetFolder, new ExtractionOptions() {
+							ExtractFullPath = true,
+							Overwrite = true
+						});
+					}
+				}
+			}
+
+			TaskDone();
+			return true;
+		}
+	}
+}

--- a/src/CommunityPatchLauncher/packages.config
+++ b/src/CommunityPatchLauncher/packages.config
@@ -2,6 +2,9 @@
 <packages>
   <package id="FontAwesome.WPF" version="4.7.0.9" targetFramework="net461" />
   <package id="Markdig" version="0.20.0" targetFramework="net461" />
+  <package id="Microsoft.WindowsAPICodePack-Core" version="1.1.0.0" targetFramework="net461" />
+  <package id="Microsoft.WindowsAPICodePack-Shell" version="1.1.0.0" targetFramework="net461" />
+  <package id="SharpCompress" version="0.26.0" targetFramework="net461" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net461" />
   <package id="System.Memory" version="4.5.4" targetFramework="net461" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net461" />


### PR DESCRIPTION
- Changed FolderBrowserDialogue to Microsoft.WindowsAPICodePack.Dialogs.CommonOpenFileDialog
- Created a task to unzip the downloaded Patch as a whole and extract its contents directly to the game path

New Dependencies:
- SharpCompress (Uses MIT Licence)
- Microsoft.WindowsAPICodePack (Uses [Proprietary Licence](http://web.archive.org/web/20111225151819/http://archive.msdn.microsoft.com/WindowsAPICodePack/Project/License.aspx))