### PR TITLE
Feature/pre install steps

### DIFF
--- a/docs/en-EN/Changelog.md
+++ b/docs/en-EN/Changelog.md
@@ -13,6 +13,7 @@
 
 * Describing texts for all versions added in german and english
 * Community DLC is getting installed for all patches
+* Support for pre installation steps
 
 ### Fixed
 

--- a/src/CommunityPatchLauncher/App.config
+++ b/src/CommunityPatchLauncher/App.config
@@ -37,6 +37,9 @@
             <setting name="ReportIssueLink" serializeAs="String">
                 <value>https://github.com/Settlers4Modding/CommunityPatchLauncher/issues</value>
             </setting>
+            <setting name="PreInstall" serializeAs="String">
+                <value>PreInstall.txt</value>
+            </setting>
         </CommunityPatchLauncher.Properties.Settings>
     </userSettings>
 </configuration>

--- a/src/CommunityPatchLauncher/Properties/Settings.Designer.cs
+++ b/src/CommunityPatchLauncher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CommunityPatchLauncher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.6.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.7.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -128,6 +128,18 @@ namespace CommunityPatchLauncher.Properties {
             }
             set {
                 this["ReportIssueLink"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("PreInstall.txt")]
+        public string PreInstall {
+            get {
+                return ((string)(this["PreInstall"]));
+            }
+            set {
+                this["PreInstall"] = value;
             }
         }
     }

--- a/src/CommunityPatchLauncher/Properties/Settings.settings
+++ b/src/CommunityPatchLauncher/Properties/Settings.settings
@@ -29,5 +29,8 @@
     <Setting Name="ReportIssueLink" Type="System.String" Scope="User">
       <Value Profile="(Default)">https://github.com/Settlers4Modding/CommunityPatchLauncher/issues</Value>
     </Setting>
+    <Setting Name="PreInstall" Type="System.String" Scope="User">
+      <Value Profile="(Default)">PreInstall.txt</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/CommunityPatchLauncher/Tasks/UnzipAndExtractCommunityPatchTask.cs
+++ b/src/CommunityPatchLauncher/Tasks/UnzipAndExtractCommunityPatchTask.cs
@@ -5,6 +5,9 @@ using System.Linq;
 using SharpCompress.Common;
 using SharpCompress.Archives;
 using SharpCompress.Archives.Zip;
+using CommunityPatchLauncherFramework.Settings.Factories;
+using CommunityPatchLauncher.Settings.Factories;
+using CommunityPatchLauncherFramework.Settings.Manager;
 
 namespace CommunityPatchLauncher.Tasks
 {
@@ -48,6 +51,7 @@ namespace CommunityPatchLauncher.Tasks
 				}
 
 				using (var extractedGame = ZipArchive.Open(innerArchive)) {
+					DoPreInstallSteps(extractedGame);
 					foreach (var entry in extractedGame.Entries.Where(entry => !entry.IsDirectory)) {
 						entry.WriteToDirectory(targetFolder, new ExtractionOptions() {
 							ExtractFullPath = true,
@@ -59,6 +63,49 @@ namespace CommunityPatchLauncher.Tasks
 
 			TaskDone();
 			return true;
+		}
+
+		/// <summary>
+		/// Get a specific entry from the archive
+		/// </summary>
+		/// <param name="entryName">The entry name to get</param>
+		/// <param name="archive">The archive to search in</param>
+		/// <returns>The entry or null</returns>
+		private ZipArchiveEntry GetSpecificEntry(string entryName, ZipArchive archive)
+        {
+			var entryToReturn = archive.Entries.Where(entry => 
+			{
+				return entry.IsDirectory == false && entry.Key == entryName;
+			}).FirstOrDefault();
+			return entryToReturn;
+        }
+
+		/// <summary>
+		/// Do the pre installation steps
+		/// </summary>
+		/// <param name="zipArchive"></param>
+		private void DoPreInstallSteps(ZipArchive zipArchive)
+        {
+			ISettingFactory settingFactory = new WpfPropertySettingManagerFactory();
+			SettingManager applicationSettings = settingFactory.GetSettingsManager();
+			string preInstallFileName = applicationSettings.GetValue<string>("PreInstall");
+			ZipArchiveEntry preInstall = GetSpecificEntry(preInstallFileName, zipArchive);
+			if (preInstall != null)
+			{
+				using (StreamReader fileReader = new StreamReader(preInstall.OpenEntryStream()))
+				{
+					string line = string.Empty;
+					while ((line = fileReader.ReadLine()) != null)
+					{
+						string gameFolder = settingManager.GetValue<string>("GameFolder");
+						string fullPath = gameFolder + line;
+						if (File.Exists(fullPath))
+                        {
+							File.Delete(fullPath);
+                        }
+					}
+				}
+			}
 		}
 	}
 }

--- a/src/CommunityPatchLauncher/Tasks/UnzipAndExtractCommunityPatchTask.cs
+++ b/src/CommunityPatchLauncher/Tasks/UnzipAndExtractCommunityPatchTask.cs
@@ -97,6 +97,7 @@ namespace CommunityPatchLauncher.Tasks
 					string line = string.Empty;
 					while ((line = fileReader.ReadLine()) != null)
 					{
+						//TODO: IMPORTANT: Check if this is enough protection so that nobody can escape the game folder!
 						line = line.Replace("../", "");
 						line = line.Replace("..\\", "");
 						string gameFolder = settingManager.GetValue<string>("GameFolder");

--- a/src/CommunityPatchLauncher/Tasks/UnzipAndExtractCommunityPatchTask.cs
+++ b/src/CommunityPatchLauncher/Tasks/UnzipAndExtractCommunityPatchTask.cs
@@ -97,6 +97,8 @@ namespace CommunityPatchLauncher.Tasks
 					string line = string.Empty;
 					while ((line = fileReader.ReadLine()) != null)
 					{
+						line = line.Replace("../", "");
+						line = line.Replace("..\\", "");
 						string gameFolder = settingManager.GetValue<string>("GameFolder");
 						string fullPath = gameFolder + line;
 						if (File.Exists(fullPath))


### PR DESCRIPTION
This update will add the possiblity of pre installations steps for the patches. Those steps need to be defined in the .zip file contained inside the 7z. 
The file must be named "PreInstall.txt" and can contain one file per line which will be deleted. Those files will be deleted in the game folder.

Fixing #53 